### PR TITLE
Add taskErrorHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,14 +758,14 @@ for _, result := range results {
 }
 ```
 
-#### Error Handling
+#### Task Error Handling
 
 When a task returns with an error, the default behavior is to first attempty to retry the task if it's retriable, otherwise log the error and then eventually call any error callbacks.
 
 To customize this, you can set a custom error handler on the worker which can do more than just logging after retries fail and error callbacks are trigerred:
 
 ```go
-worker.SetErrorHandler(func (err error) {
+worker.SetTaskErrorHandler(func (err error) {
   customHandler(err)
 })
 ```

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -27,6 +27,7 @@ type Worker struct {
 	Concurrency       int
 	Queue             string
 	errorHandler      func(err error)
+	taskErrorHandler  func(*tasks.Signature, error)
 	preTaskHandler    func(*tasks.Signature)
 	postTaskHandler   func(*tasks.Signature)
 	preConsumeHandler func(*Worker) bool
@@ -365,7 +366,7 @@ func (worker *Worker) taskFailed(signature *tasks.Signature, taskErr error) erro
 	}
 
 	if worker.errorHandler != nil {
-		worker.errorHandler(taskErr)
+		worker.taskErrorHandler(signature, taskErr)
 	} else {
 		log.ERROR.Printf("Failed processing task %s. Error = %v", signature.UUID, taskErr)
 	}
@@ -398,6 +399,10 @@ func (worker *Worker) hasAMQPBackend() bool {
 // A default behavior is just to log the error after all the retry attempts fail
 func (worker *Worker) SetErrorHandler(handler func(err error)) {
 	worker.errorHandler = handler
+}
+
+func (worker *Worker) SetTaskErrorHandler(handler func(signature *tasks.Signature, err error)) {
+	worker.taskErrorHandler = handler
 }
 
 //SetPreTaskHandler sets a custom handler func before a job is started


### PR DESCRIPTION
For failed tasks, it is helpful to have the task signature.
This commit adds a taskErrorHandler that will pass along the signature and error
to be called when a task is out of retries.